### PR TITLE
fix(): Reverse pump order.

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -34,11 +34,11 @@ class Protocol extends Duplex {
     this.pending = new Map()
 
     if (opts && 'function' === typeof opts.connect) {
-      process.nextTick(pump, this, opts.connect(this), this)
+      process.nextTick(pump, opts.connect(this), this, opts.connect(this))
     }
 
     if (opts && opts.stream) {
-      process.nextTick(pump, this, opts.stream, this)
+      process.nextTick(pump, opts.stream, this, opts.stream)
     }
   }
 

--- a/protocol.js
+++ b/protocol.js
@@ -34,7 +34,8 @@ class Protocol extends Duplex {
     this.pending = new Map()
 
     if (opts && 'function' === typeof opts.connect) {
-      process.nextTick(pump, opts.connect(this), this, opts.connect(this))
+      const conn = opts.connect(this)
+      process.nextTick(pump, conn, this, conn)
     }
 
     if (opts && opts.stream) {


### PR DESCRIPTION
Unless there is a good reason, I think this would be a better pump order.

1. It makes it so noise-peer can end cleanly.
2. Its cleaner to think about the outer streams wrapping the inner most stream?

I'm not 100% on 2, but 1 is defiantly true.  There is also a local solution I can put into secure-rpc-protocol that does this.